### PR TITLE
Missing when condition for empty `redis_save`

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -61,6 +61,7 @@
     line: 'include {{ redis_custom_config }}'
     insertbefore: '{{ redis_save[0] }}'
     state: 'present'
+  when: redis_save is defined and redis_save
   notify: ['Restart Redis Server']
 
 - name: Insert templated values to the main Redis config


### PR DESCRIPTION
This was breaking the role when `redis_save: []`