### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Added
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.redis v0.2.1`_ - 2016-11-18

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,8 @@ Added
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.redis v0.2.1`_ - 2016-11-18

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@ Added
   a background save if it uses more than half of the available memory with
   overcommit disabled. [scibi_]
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.redis v0.2.1`_ - 2016-11-18
 -----------------------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Install and manage Redis cluster'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '/etc/redis/*.dpkg-divert' | awk '{print $NF}'
   register: redis__register_diversions
-  check_mode: no
+  check_mode: False
   changed_when: False
 
 - name: Divert the original Redis config files

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '/etc/redis/*.dpkg-divert' | awk '{print $NF}'
   register: redis__register_diversions
-  always_run: True
+  check_mode: no
   changed_when: False
 
 - name: Divert the original Redis config files


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.