### PR TITLE
Disable Transparent Huge Pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Added
   a background save if it uses more than half of the available memory with
   overcommit disabled. [scibi_]
 
+- Disable Transparent Huge Pages by default. THP create latency and memory
+  usage issues with Redis. [scibi_]
+
 Fixed
 ~~~~~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -248,6 +248,13 @@ redis__server_maxmemory_policy: 'volatile-lru'
 redis__overcommit_memory_enable: True
 
                                                                    # ]]]
+# .. envvar:: redis__transparent_huge_pages_disable [[[
+#
+# Disable kernel.mm.transparent_hugepage.enabled. Transparent Huge Pages (THP)
+# create latency and memory usage issues with Redis.
+redis__transparent_huge_pages_disable: True
+
+                                                                   # ]]]
 # .. envvar:: redis__server_maxmemory_samples [[[
 #
 # Number of samples taken by Redis Server to perform memory management

--- a/tasks/disable-thp.yml
+++ b/tasks/disable-thp.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Install disable-transparent-hugepages unit file
+  template:
+    src: 'etc/systemd/system/disable-transparent-hugepages.service.j2'
+    dest: '/etc/systemd/system/disable-transparent-hugepages.service'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  register: redis__register_disable_thp_unit_install
+
+- name: Reload systemd daemons
+  command: systemctl daemon-reload
+  when: redis__register_disable_thp_unit_install|changed
+
+- name: Start disable-transparent-hugepages service
+  service:
+    name: 'disable-transparent-hugepages'
+    state: 'started'
+    enabled: True
+  when: redis__register_disable_thp_unit_install|changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,10 @@
     sysctl_file: '/etc/sysctl.d/30-redis.conf'
   when: redis__overcommit_memory_enable|bool
 
+- name: Disable Transparent Huge Pages
+  include: disable-thp.yml
+  when: redis__transparent_huge_pages_disable|bool
+
 - name: Configure redis-server service
   include: redis-server.yml
   when: redis__server_enabled|bool

--- a/templates/etc/systemd/system/disable-transparent-hugepages.service.j2
+++ b/templates/etc/systemd/system/disable-transparent-hugepages.service.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description="Disable Transparent Hugepage"
+Before=redis-server.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'echo never > /sys/kernel/mm/transparent_hugepage/enabled'
+ExecStart=/bin/bash -c 'echo never > /sys/kernel/mm/transparent_hugepage/defrag'
+
+[Install]
+RequiredBy=redis-server.service


### PR DESCRIPTION
Currently Redis logs following warning on start:

> WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.

This PR adds a service which disables THP before starting Redis.